### PR TITLE
Adding initial component yaml spec documentation for App manifest. TODO: lifecycle, resource, route

### DIFF
--- a/docs/Manifests.md
+++ b/docs/Manifests.md
@@ -1,6 +1,197 @@
 # Manifests
 
-## AppManifest
+## AppManifest Specification
+
+The AppManifest YAML file defines your application's components, routes, resources, and lifecycle events.  
+
+
+
+### Components top-level element
+
+An AppManifest must declare a `components` root element as a list of objects containing configuration for each component in your application. At least one component object must be defined.
+
+```yaml
+components:
+  - name: webserver
+    ...
+  - name: api
+    ...
+```
+
+<!-- <details> -->
+
+#### name
+Defines the name of the component. Each component `name` must be unique. **Required**.
+
+#### type
+
+Specifies the type of the component; must be one of `service`, `task`, or `static`. **Required**.
+
+
+#### image
+
+Sets the base image from which the component is built. **Required**.
+
+
+#### port
+
+The container port to expose.
+
+#### root
+
+Establishes the docker build context, setting the host working directory for `copy` and `run` build step commands. 
+
+#### build
+
+ Defines a series of `steps` to be executed in creating the component image. Steps are defined as an array of mappings, where the mapping key is the step instruction and mapping value are arguments for that instruction. 
+
+ Steps:
+
+ ##### directory
+
+ Sets the working directory of the image for build step commands that follow. 
+
+##### copy
+
+ Copies files from the host to the image. The copy step can take both string and array types as an argument. Strings can use the wildcard symbol '*' to pattern match files. Arrays must have at least one element, where elements represent individual files to be copied from host to image. The copy step object can be used in conjunction with the optional `destination` key to specify the image directory in which files are to be copied.
+
+```yaml
+...
+    build:
+      steps:
+        - directory: /express
+        - copy: package*.json
+          destination: ./
+        - copy: [index.js, dynamodb.js, s3.js]
+          destination: ./
+    ...
+``` 
+
+##### run
+
+Executes a command in the current working directory. If no directory step precedes the run step, the command will execute in the base image's working directory.
+
+##### image
+
+Specifies an image to be used for multi-stage builds. The optional `stage` key can be used to name the build stage. The build stage should be a `string` value and cannot equal `main`, which is the name of the primary build stage.
+
+```yaml
+    build:
+      steps:
+      ...
+        - image: node:10
+          stage: server-build
+      ...
+``` 
+
+#### runtime
+
+`runtime` defines properties associated with a component instance. `runtime` properties affect build [Deployments](/docs/Deployments.md), specifying container execution commands, instance memory, component resources, and component variables.
+
+##### resources
+
+Resources that a component will use must be defined in the `resources` property of a component's runtime section. Resources are an array of strings, where the string value corresponds to the name of the resource as defined in the AppManifest resources (provide link) section.
+
+
+```yaml
+...
+    runtime: 
+      resources:
+        - DynamoDBTable
+        - S3Bucket
+    ...
+resources:
+  - name: DynamoDBTable
+    type: dynamodb
+    hashKeyName: id
+    hashKeyType: S
+  - name: S3Bucket
+    type: s3
+``` 
+
+##### entrypoint
+
+Defines a container ENTRYPOINT instruction used to specify a command that will be executed when the container starts.
+
+##### command
+
+Defines a container CMD instruction used to specify a command that will be executed when the container starts. If used in conjunction with `entrypoint`, the value of `command` specifies arguments that will be passed to the `entrypoint` command. 
+
+##### cpu
+
+Used to specify the number of cpu cores of a component instance.
+
+##### memory
+
+Used to specify the memory (in MB) of a component instance.
+
+##### variables
+
+Defines variables to be used at runtime. Each variable is a mapping object, where the object key is the variable name and object value is the variable value. Variables can make use of Noop logic to access object values within certain scopes. A common pattern to assign a variable the value of a resource property is to use the `$resources` scope object with the corresponding resource object and property.
+
+```yaml
+    runtime: 
+    ...
+      variables:
+        S3_BUCKET:
+          $resources: ImagesBucket.bucket
+        S3_ENDPOINT:
+          $resources: ImagesBucket.endpoint
+        LOG_LEVEL: info
+``` 
+
+<br>
+ 
+<!-- <details> -->
+
+
+<!-- </details> -->
+
+<!-- </details> -->
+
+<!--
+|              **Field**                   | **Type** |                                      **Description**                                      |
+|:----------------------------------------:|:--------:|:-----------------------------------------------------------------------------------------:|
+|  <span id="components-name">name</span>     | `string` |                 **_REQUIRED_** The name of the component; must be unique.                 |
+|  <span id="components-type">type</span>     | `string` | **_REQUIRED_** The type of the component; must be one of `service`, `task`, or `static`.  |
+| <span id="components-image">image</span>    | `string` |                                 **_REQUIRED_** The image                                  |
+| <span id="components-port">port</span>      | `int`    |                                 _OPTIONAL_ The container port to expose.                  |
+| <span id="components-port">root</span>      | `string` |  _OPTIONAL_ Sets the working directory for **copy** and **run** build step commands       |
+| <span id="components-scaling">scaling</span>| `string` |  _OPTIONAL_ Sets the working directory for **copy** and **run** build step commands       |
+
+-->
+
+<!--
+#### **scaling**
+
+`scaling` Sets scaling policies for component instances in a stack.
+
+```yaml
+components:
+  - name: webserver
+    type: service
+    image: nginx
+    port: 80
+    scaling:
+      # minimum: 1
+      # maximum: 3
+      target: 2
+      # autopilot: true
+```
+##### **minimum**
+`minimum` The minimum number of instances present in a stack at all times. When a scale down event occurs, the number of remaining instances in the stack will never be less than this number.
+
+##### **maximum**
+`maximum` The maximum number of instances present in a stack at all times. When a scale up event occurs, the number of instances in the stack will never be greater than this number
+
+##### **target**
+`target` 
+
+-->
+
+
+
+## AppManifest Sample
 
 Expressed in Source Code at `.noop/app.yml`
 

--- a/docs/Manifests.md
+++ b/docs/Manifests.md
@@ -4,8 +4,6 @@
 
 The AppManifest YAML file defines your application's components, routes, resources, and lifecycle events.  
 
-
-
 ### Components top-level element
 
 An AppManifest must declare a `components` root element as a list of objects containing configuration for each component in your application. At least one component object must be defined.

--- a/docs/Manifests.md
+++ b/docs/Manifests.md
@@ -2,7 +2,7 @@
 
 ## AppManifest Specification
 
-The AppManifest YAML file defines your application's components, routes, resources, and lifecycle events.  
+The AppManifest YAML file defines your application's components, routes, resources, and lifecycle events.
 
 ### Components top-level element
 
@@ -19,17 +19,16 @@ components:
 <!-- <details> -->
 
 #### name
+
 Defines the name of the component. Each component `name` must be unique. **Required**.
 
 #### type
 
 Specifies the type of the component; must be one of `service`, `task`, or `static`. **Required**.
 
-
 #### image
 
 Sets the base image from which the component is built. **Required**.
-
 
 #### port
 
@@ -37,21 +36,21 @@ The container port to expose.
 
 #### root
 
-Establishes the docker build context, setting the host working directory for `copy` and `run` build step commands. 
+Establishes the docker build context, setting the host working directory for `copy` and `run` build step commands.
 
 #### build
 
- Defines a series of `steps` to be executed in creating the component image. Steps are defined as an array of mappings, where the mapping key is the step instruction and mapping value are arguments for that instruction. 
+Defines a series of `steps` to be executed in creating the component image. Steps are defined as an array of mappings, where the mapping key is the step instruction and mapping value are arguments for that instruction.
 
- Steps:
+Steps:
 
- ##### directory
+##### directory
 
- Sets the working directory of the image for build step commands that follow. 
+Sets the working directory of the image for build step commands that follow.
 
 ##### copy
 
- Copies files from the host to the image. The copy step can take both string and array types as an argument. Strings can use the wildcard symbol '*' to pattern match files. Arrays must have at least one element, where elements represent individual files to be copied from host to image. The copy step object can be used in conjunction with the optional `destination` key to specify the image directory in which files are to be copied.
+Copies files from the host to the image. The copy step can take both string and array types as an argument. Strings can use the wildcard symbol '\*' to pattern match files. Arrays must have at least one element, where elements represent individual files to be copied from host to image. The copy step object can be used in conjunction with the optional `destination` key to specify the image directory in which files are to be copied.
 
 ```yaml
 ...
@@ -63,7 +62,7 @@ Establishes the docker build context, setting the host working directory for `co
         - copy: [index.js, dynamodb.js, s3.js]
           destination: ./
     ...
-``` 
+```
 
 ##### run
 
@@ -80,7 +79,7 @@ Specifies an image to be used for multi-stage builds. The optional `stage` key c
         - image: node:10
           stage: server-build
       ...
-``` 
+```
 
 #### runtime
 
@@ -90,10 +89,9 @@ Specifies an image to be used for multi-stage builds. The optional `stage` key c
 
 Resources that a component will use must be defined in the `resources` property of a component's runtime section. Resources are an array of strings, where the string value corresponds to the name of the resource as defined in the AppManifest resources (provide link) section.
 
-
 ```yaml
 ...
-    runtime: 
+    runtime:
       resources:
         - DynamoDBTable
         - S3Bucket
@@ -105,7 +103,7 @@ resources:
     hashKeyType: S
   - name: S3Bucket
     type: s3
-``` 
+```
 
 ##### entrypoint
 
@@ -113,7 +111,7 @@ Defines a container ENTRYPOINT instruction used to specify a command that will b
 
 ##### command
 
-Defines a container CMD instruction used to specify a command that will be executed when the container starts. If used in conjunction with `entrypoint`, the value of `command` specifies arguments that will be passed to the `entrypoint` command. 
+Defines a container CMD instruction used to specify a command that will be executed when the container starts. If used in conjunction with `entrypoint`, the value of `command` specifies arguments that will be passed to the `entrypoint` command.
 
 ##### cpu
 
@@ -128,7 +126,7 @@ Used to specify the memory (in MB) of a component instance.
 Defines variables to be used at runtime. Each variable is a mapping object, where the object key is the variable name and object value is the variable value. Variables can make use of Noop logic to access object values within certain scopes. A common pattern to assign a variable the value of a resource property is to use the `$resources` scope object with the corresponding resource object and property.
 
 ```yaml
-    runtime: 
+    runtime:
     ...
       variables:
         S3_BUCKET:
@@ -136,12 +134,11 @@ Defines variables to be used at runtime. Each variable is a mapping object, wher
         S3_ENDPOINT:
           $resources: ImagesBucket.endpoint
         LOG_LEVEL: info
-``` 
+```
 
 <br>
  
 <!-- <details> -->
-
 
 <!-- </details> -->
 
@@ -183,11 +180,9 @@ components:
 `maximum` The maximum number of instances present in a stack at all times. When a scale up event occurs, the number of instances in the stack will never be greater than this number
 
 ##### **target**
-`target` 
+`target`
 
 -->
-
-
 
 ## AppManifest Sample
 


### PR DESCRIPTION
I'm submitting this as a draft PR just so you can take a look and I can get your thoughts on the direction I have taken with this. I've only finished the component spec and need to finish and link lifecycles, routes, and resources specifications.

 I ended up formatting this in a way similar to the docker-compose specifications which seemed to align with the way we are generating table of contents on the right side of the documentation pane. You can see in the commented-out portion I experimented with doing this as a table, but the table rows wouldn't have been accessible in the table of contents.

Let me know your thoughts. Apologies for any technical inaccuracies in the descriptions.