### PR TITLE
Search Index Hotfix

### DIFF
--- a/pagefind.yml
+++ b/pagefind.yml
@@ -1,0 +1,2 @@
+site: dist
+output_subdir: assets/docs/pagefind


### PR DESCRIPTION
adding pagefind config so that the search index lives under the route alongside other documentation assets