### PR TITLE
Fixing search index and results

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -9,5 +9,5 @@ export default defineConfig({
         assets: 'assets/docs/_astro'
     },
 
-    integrations: [tailwind(), pagefind({site: 'dist', outputSubdir: 'assets/docs/pagefind'})]
+    integrations: [tailwind(), pagefind({site: 'dist', outputSubdir: 'assets/docs/pf'})]
 })

--- a/lib/astro-pagefind/pagefind.ts
+++ b/lib/astro-pagefind/pagefind.ts
@@ -13,6 +13,8 @@ export default function pagefind(pagefindConfig: { site?: string; outputSubdir?:
   process.env.PAGEFIND_SITE = site
 
   let outDir: string;
+
+
   return {
     name: "pagefind",
     hooks: {

--- a/pagefind.yml
+++ b/pagefind.yml
@@ -1,2 +1,0 @@
-site: distoooooo
-output_subdir: assets/docs/pagefind

--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -9,11 +9,11 @@ const {id} = Astro.props
 <style is:global>
 
  :root {
-   --pagefind-ui-background: #334155;
-   --pagefind-ui-primary: #eeeeee;
-	 --pagefind-ui-text: #eeeeee;
-	 --pagefind-ui-border: #334155;
-	 --pagefind-ui-tag: #000;
+   --pagefind-ui-background: #334155 !important;
+   --pagefind-ui-primary: #eeeeee !important;
+	 --pagefind-ui-text: #eeeeee !important;
+	 --pagefind-ui-border: #334155 !important;
+	 --pagefind-ui-tag: #000 !important;
  }
 
 

--- a/src/layouts/Doc.astro
+++ b/src/layouts/Doc.astro
@@ -5,7 +5,7 @@ const { content = {}, headings } = Astro.props
 ---
 
 <Layout data={content}>
-  <main class="lg:col-span-6 col-span-12">
+  <main class="lg:col-span-6 col-span-12" data-pagefind-body>
     <article>
       <header>
         <h3 class="text-xs font-mono uppercase text-fuchsia-500">


### PR DESCRIPTION
fixing the pagefind content index and also changing the output subdir to something other than "pagefind" because that breaks the content urls for some reason