### PR TITLE
Integrate Posthog configuration with LocalStorage values provided by the Console

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -49,32 +49,36 @@ const { data = {} } = Astro.props
     </script>
 
 
-    <script>
+    <script async>
+     const persistence = (window.localStorage.getItem('NOOP_COOKIE_CONSENT') === 'ACCEPT') || window.localStorage.getItem('NOOP_IDENTITY')
+       ? 'localStorage+cookie'
+       : 'memory'
 
+     let guestId = window.localStorage.getItem('NOOP_GUEST')
+     if (!guestId) guestId = window.localStorage.getItem('NOOP_PH_UID')
+     if (!guestId) guestId = `/guests/${window.crypto.getRandomValues(new Uint32Array(1))[0]}`
+     window.localStorage.setItem('NOOP_GUEST', guestId)
+     window.localStorage.setItem('NOOP_PH_UID', guestId)
+
+     const identityId = window.localStorage.getItem('NOOP_IDENTITY')
+
+     const distinctID = identityId || guestId
+    
      const config = {
-       api_host:'https://app.posthog.com',
-       persistence: 'memory'
-     }
-
-     const phUid = window.localStorage.getItem('NOOP_PH_UID')
-
-
-     if (phUid) {
-       config.bootstrap = {
-         distinctID: phUid
-       }
-     } else {
-       config.bootstrap = {
-         distinctID: Math.random().toString(16).slice(2)
+       api_host:'https://us.i.posthog.com',
+       persistence,
+       bootstrap: { distinctID, isIdentifiedID: true },
+       loaded: posthog => {
+         posthog.identify(...[distinctID, identityId ? { personId: identityId } : null].filter(Boolean))
+         if (distinctID !== guestId) {
+           posthog.capture('$merge_dangerously', { alias: guestId })
+         }
        }
      }
 
      !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
      posthog.init('phc_Kcoobpt8LhiXOQrSOEa7sj74uTbD4VAsaSJSBsNSmf3', config)
 
-     posthog.onSessionId(() => {
-       window.localStorage.setItem('NOOP_PH_UID', posthog.get_distinct_id())
-     })
     </script>
 
     <script>


### PR DESCRIPTION
- Conditionally enable Posthog with `'localStorage+cookie'` persistence
- Use `NOOP_IDENTITY` as a `distinctID` value with Posthog if it exists in LocalStorage
- Migrate prior `NOOP_PH_UID` LocalStorage items to `NOOP_GUEST`
- Introduce new pattern for anonymous user ids prefix by `/guests/` (existing anonymous user ids are left as-is)